### PR TITLE
Redirect downloads to local IPFS gateway

### DIFF
--- a/background.js
+++ b/background.js
@@ -26,3 +26,51 @@ browser.webRequest.onBeforeRequest.addListener(
   {urls:[pattern]},
   ["blocking"]
 );
+
+/*
+  Redirect downloads
+
+  UX PoC for downloading files from web using native IPFS
+
+  Downloads files from local IPFS gateway when the website
+  specifies 'IPFS_DOWNLOAD=Qm...Foo' in a link. Eg.
+
+  <a href="http://ovh.net/files/1Gb.dat?IPFS_DOWNLOAD=QmWKW2E4qHTUeYXtiEQpZ7eX3aNoNnWc4d9g3NW1CuyUCq">
+
+  What happens here:
+  1. User downloads a file from a URL, gets asked
+     for where to save the file, like normally.
+  2. Download is created by the browser.
+  3. We capture the newly-created download and cancel it
+     if we find 'IPFS_DOWNLOAD=Qm...Foo' in the URL. 
+     For example:
+     http://ovh.net/files/1Gb.dat?IPFS_DOWNLOAD=QmWKW2E4qHTUeYXtiEQpZ7eX3aNoNnWc4d9g3NW1CuyUCq
+  4. We ask the browser to download the hash from local IPFS gateway
+     with the original filename.
+
+  Limitations:
+  - Websites need to add 'IPFS_DOWNLOAD=Qm...Foo' to their <a> tags
+  - With the current flow, files are always saved in browser's default
+    download directory regardless where user saved it when prompted.
+ */
+function handleDownloadRequest(downloadItem) {
+  console.log("Download:", downloadItem)
+
+  const match = downloadItem.url.match(/\bIPFS_DOWNLOAD=Qm\w{44}\b/)
+  const multihash = match ? match[0].replace("IPFS_DOWNLOAD=", "") : null
+
+  if (multihash) {
+    browser.downloads.cancel(downloadItem.id)
+      .then(() => {
+        const downloadUrl = localgatewayurl + "/ipfs/" + multihash
+        const filename = downloadItem.filename.split("/").pop()
+        console.log("multihash:", multihash, downloadUrl)
+        browser.downloads.download({ 
+          url: downloadUrl,
+          filename: filename,
+        })
+      })
+  }
+}
+
+browser.downloads.onCreated.addListener(handleDownloadRequest)

--- a/manifest.json
+++ b/manifest.json
@@ -24,9 +24,10 @@
   },
  
   "permissions": [
-	  "nativeMessaging",
-	  "webRequest",
-	  "webRequestBlocking"
+    "nativeMessaging",
+    "webRequest",
+    "webRequestBlocking",
+    "downloads"
   ]
 
 }


### PR DESCRIPTION
I added a small prototype of how "native IPFS downloads" would feel. This is a UX prototype and not necessarily how we should technically implement it, rather how it would feel as a user to be downloading at light speeds! 😄 

Basic idea is that if a link contains `IPFS_DOWNLOAD=Qm...Foo`, the add-on will download the file from the local gateway. See the code for more detailed comments.